### PR TITLE
Restore neon effects and effects systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,157 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AstroBies</title>
     <style>
-      html, body { height: 100%; }
-      * { box-sizing: border-box; margin: 0; padding: 0; }
-      body { background: #0a0a0f; color: #e6faff; font-family: system-ui, sans-serif; }
-      #app { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
-      #gameCanvas { display: block; width: 100%; height: 100%; background: #0a0a0f; }
-      #hud { position: absolute; inset: 0; pointer-events: none; }
+      :root {
+        color-scheme: dark;
+        font-family: 'Segoe UI', 'Rajdhani', 'Roboto', sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at 20% 20%, #1a1024, #05040a 65%);
+        background-size: 120% 120%;
+        animation: bgShift 20s ease-in-out infinite alternate;
+        color: #e6faff;
+      }
+
+      #app {
+        position: relative;
+        width: min(1180px, 92vw);
+        height: min(720px, 92vh);
+        border-radius: 16px;
+        overflow: hidden;
+        background: linear-gradient(160deg, rgba(5, 6, 15, 0.9), rgba(20, 8, 32, 0.82));
+        border: 2px solid rgba(0, 255, 255, 0.35);
+        box-shadow:
+          0 0 30px rgba(0, 255, 255, 0.35),
+          0 0 80px rgba(255, 0, 120, 0.25),
+          inset 0 0 35px rgba(0, 255, 255, 0.08);
+      }
+
+      #app::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        border-radius: inherit;
+        border: 1px solid rgba(0, 255, 255, 0.2);
+        box-shadow: 0 0 60px rgba(0, 255, 255, 0.45);
+        mix-blend-mode: screen;
+      }
+
+      #gameCanvas {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+        background: transparent;
+      }
+
+      #hud {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        padding: 24px;
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-start;
+      }
+
+      .hud-container {
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+        min-width: 220px;
+        text-shadow: 0 0 14px rgba(0, 255, 255, 0.65);
+      }
+
+      .hud-row {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .hud-inline {
+        flex-direction: row;
+        gap: 16px;
+      }
+
+      .hud-pill {
+        padding: 8px 20px;
+        border-radius: 999px;
+        border: 1px solid rgba(0, 255, 255, 0.45);
+        background: linear-gradient(120deg, rgba(0, 255, 255, 0.35), rgba(255, 0, 150, 0.25));
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        box-shadow: 0 0 24px rgba(0, 255, 255, 0.35);
+      }
+
+      .hud-health-block {
+        gap: 10px;
+      }
+
+      .hud-label {
+        font-size: 0.85rem;
+        letter-spacing: 0.18em;
+        opacity: 0.9;
+      }
+
+      .hud-health {
+        position: relative;
+        width: 220px;
+        height: 26px;
+        border-radius: 10px;
+        overflow: hidden;
+        border: 1px solid rgba(0, 255, 255, 0.55);
+        background: rgba(6, 10, 18, 0.75);
+        box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55), 0 0 22px rgba(255, 0, 120, 0.35);
+      }
+
+      .hud-health-fill {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        background: linear-gradient(90deg, rgba(0, 255, 255, 0.95), rgba(255, 0, 120, 0.95));
+        box-shadow: 0 0 32px rgba(255, 0, 120, 0.5);
+        transition: width 0.25s ease;
+      }
+
+      .hud-health-text {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-shadow:
+          0 0 10px rgba(0, 0, 0, 0.85),
+          0 0 18px rgba(255, 255, 255, 0.35);
+      }
+
+      @keyframes bgShift {
+        from {
+          background-position: 0% 50%;
+        }
+        to {
+          background-position: 100% 50%;
+        }
+      }
     </style>
   </head>
   <body>

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,10 +1,22 @@
-import { initializeWorld, createPlayer, getState } from '../ecs/world';
-import { movementSystem, lifetimeSystem, spawnSystem, shootingSystem, collisionSystem, damageAndDespawnSystem, progressionSystem, playerControlSystem } from '../ecs/systems';
+import { initializeWorld, createPlayer, getState, syncPlayerState } from '../ecs/world';
+import {
+  movementSystem,
+  lifetimeSystem,
+  spawnSystem,
+  shootingSystem,
+  collisionSystem,
+  damageAndDespawnSystem,
+  progressionSystem,
+  playerControlSystem,
+} from '../ecs/systems';
 import { Renderer2D } from '../render/renderer2d';
 import { HUD } from '../ui/hud';
 import { Input } from './input';
 import { CONFIG } from '../config';
 import { Audio } from './audio';
+import { ParticleSystem } from '../systems/particles';
+import { Starfield } from '../systems/background';
+import { ScreenShake } from '../render/screenShake';
 
 // Game class - main game controller
 export class Game {
@@ -13,6 +25,9 @@ export class Game {
   private renderer: Renderer2D;
   private hud: HUD;
   private input: Input;
+  private particles = new ParticleSystem();
+  private background = new Starfield();
+  private shake = new ScreenShake();
   private world = initializeWorld();
   private running = false;
   private accumulator = 0;
@@ -31,17 +46,17 @@ export class Game {
     window.addEventListener('resize', () => this.handleResize());
 
     // Create player
-    createPlayer(this.world, this.canvas.width / this.renderer.dpr / 4, this.canvas.height / this.renderer.dpr / 2);
+    const width = this.canvas.width / this.renderer.dpr;
+    const height = this.canvas.height / this.renderer.dpr;
+    createPlayer(this.world, width * 0.25, height * 0.5);
+    syncPlayerState(this.world);
   }
 
   private handleResize() {
-    const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
-    const w = this.canvas.clientWidth || this.canvas.parentElement!.clientWidth;
-    const h = this.canvas.clientHeight || this.canvas.parentElement!.clientHeight;
-    this.canvas.width = Math.floor(w * dpr);
-    this.canvas.height = Math.floor(h * dpr);
-    this.renderer.setDPR(dpr);
-    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.renderer.resize();
+    const width = this.canvas.width / this.renderer.dpr;
+    const height = this.canvas.height / this.renderer.dpr;
+    this.background.resize(width, height);
   }
 
   public start(): void {
@@ -55,7 +70,8 @@ export class Game {
 
   private loop(ts: number): void {
     if (!this.running) return;
-    const dtMs = ts - this.lastTs; this.lastTs = ts;
+    const dtMs = ts - this.lastTs;
+    this.lastTs = ts;
     let dt = Math.min(0.25, dtMs / 1000);
     this.accumulator += dt;
     const step = CONFIG.fixedDelta;
@@ -66,20 +82,26 @@ export class Game {
       const isShooting = this.input.isPointerDown || this.input.keys.has('Space');
       playerControlSystem(this.world, this.input);
       movementSystem(this.world, step);
-      spawnSystem(this.world, step, this.canvas.width / this.renderer.dpr, this.canvas.height / this.renderer.dpr);
-      shootingSystem(this.world, step, isShooting);
+      const width = this.canvas.width / this.renderer.dpr;
+      const height = this.canvas.height / this.renderer.dpr;
+      spawnSystem(this.world, step, width, height);
+      shootingSystem(this.world, step, isShooting, this.particles, this.shake);
       lifetimeSystem(this.world, step);
-      collisionSystem(this.world);
-      damageAndDespawnSystem(this.world);
+      collisionSystem(this.world, this.particles, this.shake);
+      damageAndDespawnSystem(this.world, this.particles, this.shake);
       progressionSystem(this.world);
       this.accumulator -= step;
     }
 
-    // Render
-    this.renderer.clear();
-    this.renderer.renderWorld(this.world);
+    const frameDt = dtMs / 1000;
+    this.background.update(frameDt);
+    this.particles.syncTrails(this.world);
+    this.particles.update(frameDt);
+
+    this.renderer.render(this.world, this.background, this.particles, this.shake);
 
     // HUD
+    syncPlayerState(this.world);
     this.hud.update(getState(this.world));
 
     requestAnimationFrame((now) => this.loop(now));

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -2,25 +2,55 @@
 import { createWorld, addComponent, addEntity } from 'bitecs';
 import { Position, Velocity, Health, Size, Render, Player, Enemy, Bullet, Lifetime, Damage } from './components';
 
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p: number, q: number, t: number) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
 export interface GameState {
   score: number;
   wave: number;
   level: number;
   time: number;
+  playerHealth: number;
+  playerMaxHealth: number;
 }
 
 // Define the World type
 export type World = ReturnType<typeof createWorld>;
 
+function createInitialState(): GameState {
+  return { score: 0, wave: 1, level: 1, time: 0, playerHealth: 100, playerMaxHealth: 100 };
+}
+
 // Create and export the main world instance
 export const world = createWorld(1000); // Max 1000 entities
 // Attach a small bag for global state
-(world as any).state = { score: 0, wave: 1, level: 1, time: 0 } as GameState;
+(world as any).state = createInitialState();
+(world as any).player = null;
 
 // Initialize the world
 export function initializeWorld(): World {
   const w = createWorld(1000);
-  (w as any).state = { score: 0, wave: 1, level: 1, time: 0 } as GameState;
+  (w as any).state = createInitialState();
+  (w as any).player = null;
   return w;
 }
 
@@ -37,11 +67,23 @@ export function createPlayer(w: World, x: number, y: number) {
   addComponent(w, Health, e); Health.current[e] = 100; Health.max[e] = 100;
   addComponent(w, Render, e); setColor(e, 0, 255, 255, 1);
   addComponent(w, Player, e);
+  (w as any).player = e;
+  const state = getState(w);
+  state.playerHealth = Health.current[e];
+  state.playerMaxHealth = Health.max[e];
   return e;
 }
 
 export function getState(w: World): GameState {
   return (w as any).state as GameState;
+}
+
+export function syncPlayerState(w: World): void {
+  const player = (w as any).player as number | null;
+  if (player == null) return;
+  const state = getState(w);
+  state.playerHealth = Math.max(0, Math.round(Health.current[player]));
+  state.playerMaxHealth = Math.round(Health.max[player]);
 }
 
 export function createEnemy(w: World, x: number, y: number, speed = 40) {
@@ -50,7 +92,9 @@ export function createEnemy(w: World, x: number, y: number, speed = 40) {
   addComponent(w, Velocity, e); Velocity.vx[e] = -speed; Velocity.vy[e] = 0; Velocity.vz[e] = 0;
   addComponent(w, Size, e); Size.width[e] = 16; Size.height[e] = 16;
   addComponent(w, Health, e); Health.current[e] = 10; Health.max[e] = 10;
-  addComponent(w, Render, e); setColor(e, 255, 0, 102, 1);
+  const hue = 300 + Math.random() * 60;
+  const [r, g, b] = hslToRgb(hue / 360, 1, 0.5);
+  addComponent(w, Render, e); setColor(e, r, g, b, 1);
   addComponent(w, Enemy, e);
   return e;
 }
@@ -60,7 +104,7 @@ export function createBullet(w: World, x: number, y: number, vx: number, vy: num
   addComponent(w, Position, e); Position.x[e] = x; Position.y[e] = y; Position.z[e] = 0;
   addComponent(w, Velocity, e); Velocity.vx[e] = vx; Velocity.vy[e] = vy; Velocity.vz[e] = 0;
   addComponent(w, Size, e); Size.width[e] = 4; Size.height[e] = 4;
-  addComponent(w, Render, e); setColor(e, 25, 255, 0, 1);
+  addComponent(w, Render, e); setColor(e, 255, 220, 120, 1);
   addComponent(w, Bullet, e);
   addComponent(w, Lifetime, e); Lifetime.timeLeft[e] = 2.0;
   addComponent(w, Damage, e); Damage.amount[e] = dmg;

--- a/src/render/drawBullet.ts
+++ b/src/render/drawBullet.ts
@@ -1,0 +1,21 @@
+export function drawBullet(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  color: string,
+): void {
+  ctx.shadowBlur = 20;
+  ctx.shadowColor = color;
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.shadowBlur = 8;
+  ctx.fillStyle = 'white';
+  ctx.beginPath();
+  ctx.arc(x - r * 0.3, y - r * 0.3, r * 0.35, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.shadowBlur = 0;
+}

--- a/src/render/drawEnemy.ts
+++ b/src/render/drawEnemy.ts
@@ -1,0 +1,47 @@
+export function drawEnemy(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  color: string,
+  health: number,
+  maxHealth: number,
+): void {
+  ctx.save();
+  ctx.shadowBlur = 25;
+  ctx.shadowColor = color;
+
+  const gradient = ctx.createRadialGradient(x, y, 0, x, y, r);
+  gradient.addColorStop(0, '#ffffff');
+  gradient.addColorStop(0.3, color);
+  gradient.addColorStop(1, 'rgba(0, 0, 0, 0.35)');
+  ctx.fillStyle = gradient;
+
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (health < maxHealth) {
+    const barWidth = r * 2;
+    const barHeight = 6;
+    const ratio = Math.max(0, Math.min(1, health / maxHealth));
+    const left = x - r;
+    const top = y - r - 12;
+
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+    ctx.fillRect(left, top, barWidth, barHeight);
+
+    const gradientBar = ctx.createLinearGradient(left, top, left + barWidth, top);
+    gradientBar.addColorStop(0, 'rgba(0, 255, 255, 0.9)');
+    gradientBar.addColorStop(1, color);
+    ctx.fillStyle = gradientBar;
+    ctx.fillRect(left, top, barWidth * ratio, barHeight);
+
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.4)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(left - 0.5, top - 0.5, barWidth + 1, barHeight + 1);
+  }
+
+  ctx.restore();
+}

--- a/src/render/drawPlayer.ts
+++ b/src/render/drawPlayer.ts
@@ -1,0 +1,38 @@
+export function drawPlayer(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  velocityX: number,
+  velocityY: number,
+): void {
+  ctx.save();
+  ctx.shadowBlur = 35;
+  ctx.shadowColor = '#00ffff';
+
+  const gradient = ctx.createRadialGradient(x, y, 0, x, y, r);
+  gradient.addColorStop(0, '#ffffff');
+  gradient.addColorStop(0.45, '#66ffff');
+  gradient.addColorStop(1, 'rgba(0, 255, 255, 0.45)');
+  ctx.fillStyle = gradient;
+
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.shadowBlur = 0;
+
+  // Draw heading indicator
+  const len = Math.hypot(velocityX, velocityY);
+  const dirX = len > 0.01 ? velocityX / len : 1;
+  const dirY = len > 0.01 ? velocityY / len : 0;
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.85)';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x + dirX * r * 1.6, y + dirY * r * 1.6);
+  ctx.stroke();
+
+  ctx.restore();
+}

--- a/src/render/renderer2d.ts
+++ b/src/render/renderer2d.ts
@@ -1,28 +1,86 @@
-import { World } from '../ecs/world';
-import { Position, Size, Render } from '../ecs/components';
 import { defineQuery } from 'bitecs';
+import { Bullet, Enemy, Health, Player, Position, Render, Size, Velocity } from '../ecs/components';
+import type { World } from '../ecs/world';
+import { drawPlayer } from './drawPlayer';
+import { drawEnemy } from './drawEnemy';
+import { drawBullet } from './drawBullet';
+import { ParticleSystem } from '../systems/particles';
+import { Starfield } from '../systems/background';
+import { ScreenShake } from './screenShake';
 
-const renderQ = defineQuery([Position, Size, Render]);
+const playerQuery = defineQuery([Player, Position, Velocity, Size, Health]);
+const enemyQuery = defineQuery([Enemy, Position, Velocity, Size, Health, Render]);
+const bulletQuery = defineQuery([Bullet, Position, Velocity, Size, Render]);
+
+function rgba(r: number, g: number, b: number, a = 1): string {
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+export function resizeCanvas(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D): number {
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const { clientWidth, clientHeight } = canvas;
+  const width = clientWidth || canvas.getBoundingClientRect().width;
+  const height = clientHeight || canvas.getBoundingClientRect().height;
+  canvas.width = Math.floor(width * dpr);
+  canvas.height = Math.floor(height * dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return dpr;
+}
 
 export class Renderer2D {
   public dpr = 1;
   constructor(private canvas: HTMLCanvasElement, private ctx: CanvasRenderingContext2D) {}
 
-  setDPR(dpr: number) { this.dpr = dpr; }
-
-  clear() {
-    this.ctx.fillStyle = 'rgba(10,10,15,1)';
-    this.ctx.fillRect(0, 0, this.canvas.width / this.dpr, this.canvas.height / this.dpr);
+  resize(): void {
+    this.dpr = resizeCanvas(this.canvas, this.ctx);
   }
 
-  renderWorld(world: World) {
-    const ents = renderQ(world);
-    for (let i = 0; i < ents.length; i++) {
-      const e = ents[i];
-      const r = `rgba(${Render.r[e]}, ${Render.g[e]}, ${Render.b[e]}, ${Render.alpha[e]})`;
-      this.ctx.fillStyle = r;
-      this.ctx.fillRect(Position.x[e], Position.y[e], Size.width[e], Size.height[e]);
+  render(world: World, background: Starfield, particles: ParticleSystem, shake: ScreenShake): void {
+    const width = this.canvas.width / this.dpr;
+    const height = this.canvas.height / this.dpr;
+
+    // Background fade for motion trails
+    this.ctx.fillStyle = 'rgba(10, 10, 15, 0.25)';
+    this.ctx.fillRect(0, 0, width, height);
+
+    background.draw(this.ctx);
+
+    const usedShake = shake.pre(this.ctx);
+
+    // Draw enemies with glow
+    const enemies = enemyQuery(world);
+    for (let i = 0; i < enemies.length; i++) {
+      const e = enemies[i];
+      const x = Position.x[e];
+      const y = Position.y[e];
+      const r = Math.max(Size.width[e], Size.height[e]) * 0.6;
+      const color = rgba(Render.r[e], Render.g[e], Render.b[e]);
+      drawEnemy(this.ctx, x, y, r, color, Health.current[e], Health.max[e]);
     }
+
+    // Draw player with neon gradient
+    const players = playerQuery(world);
+    for (let i = 0; i < players.length; i++) {
+      const p = players[i];
+      const x = Position.x[p];
+      const y = Position.y[p];
+      const r = Math.max(Size.width[p], Size.height[p]) * 0.65;
+      drawPlayer(this.ctx, x, y, r, Velocity.vx[p], Velocity.vy[p]);
+    }
+
+    // Draw bullets last so they bloom on top
+    const bullets = bulletQuery(world);
+    for (let i = 0; i < bullets.length; i++) {
+      const b = bullets[i];
+      const x = Position.x[b];
+      const y = Position.y[b];
+      const r = Math.max(Size.width[b], Size.height[b]) * 0.5;
+      const color = rgba(Render.r[b], Render.g[b], Render.b[b]);
+      drawBullet(this.ctx, x, y, r, color);
+    }
+
+    particles.draw(this.ctx);
+
+    shake.post(this.ctx, usedShake);
   }
 }
-

--- a/src/render/screenShake.ts
+++ b/src/render/screenShake.ts
@@ -1,0 +1,26 @@
+export class ScreenShake {
+  private magnitude = 0;
+
+  bump(amount: number): void {
+    this.magnitude = Math.min(this.magnitude + amount, 28);
+  }
+
+  pre(ctx: CanvasRenderingContext2D): boolean {
+    if (this.magnitude <= 0) return false;
+    ctx.save();
+    ctx.translate((Math.random() - 0.5) * this.magnitude, (Math.random() - 0.5) * this.magnitude);
+    return true;
+  }
+
+  post(ctx: CanvasRenderingContext2D, used: boolean): void {
+    if (used) ctx.restore();
+    if (this.magnitude > 0) {
+      this.magnitude *= 0.9;
+      if (this.magnitude < 0.5) this.magnitude = 0;
+    }
+  }
+
+  reset(): void {
+    this.magnitude = 0;
+  }
+}

--- a/src/systems/background.ts
+++ b/src/systems/background.ts
@@ -1,0 +1,73 @@
+interface Star {
+  x: number;
+  y: number;
+  radius: number;
+  baseAlpha: number;
+  alpha: number;
+  twinkleSpeed: number;
+  phase: number;
+  parallax: number;
+}
+
+export class Starfield {
+  private stars: Star[] = [];
+  private width = 0;
+  private height = 0;
+
+  constructor(private count = 160) {}
+
+  resize(width: number, height: number): void {
+    this.width = width;
+    this.height = height;
+    this.stars = new Array(this.count).fill(0).map(() => this.createStar());
+  }
+
+  private createStar(): Star {
+    return {
+      x: Math.random() * this.width,
+      y: Math.random() * this.height,
+      radius: 0.8 + Math.random() * 1.8,
+      baseAlpha: 0.35 + Math.random() * 0.45,
+      alpha: 0.4,
+      twinkleSpeed: 0.6 + Math.random() * 1.4,
+      phase: Math.random() * Math.PI * 2,
+      parallax: 0.15 + Math.random() * 0.85,
+    };
+  }
+
+  update(dt: number): void {
+    if (!this.width || !this.height) return;
+    const driftSpeed = 12;
+    for (let i = 0; i < this.stars.length; i++) {
+      const star = this.stars[i];
+      star.phase += dt * star.twinkleSpeed;
+      star.alpha = star.baseAlpha + Math.sin(star.phase) * 0.35;
+      star.y += dt * driftSpeed * star.parallax;
+      if (star.y > this.height + star.radius * 4) {
+        star.y = -star.radius * 4;
+        star.x = Math.random() * this.width;
+        star.phase = Math.random() * Math.PI * 2;
+      }
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    if (!this.width || !this.height) return;
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    for (let i = 0; i < this.stars.length; i++) {
+      const star = this.stars[i];
+      const gradient = ctx.createRadialGradient(star.x, star.y, 0, star.x, star.y, star.radius * 3);
+      gradient.addColorStop(0, 'rgba(255, 255, 255, 1)');
+      gradient.addColorStop(0.4, 'rgba(150, 220, 255, 0.8)');
+      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      ctx.globalAlpha = Math.max(0, Math.min(1, star.alpha));
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(star.x, star.y, star.radius * 2.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+    ctx.globalAlpha = 1;
+  }
+}

--- a/src/systems/particles.ts
+++ b/src/systems/particles.ts
@@ -1,0 +1,254 @@
+import type { World } from '../ecs/world';
+import { defineQuery } from 'bitecs';
+import { Bullet, Enemy, Player, Position, Render, Velocity } from '../ecs/components';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  color: string;
+  glow: number;
+  alpha: number;
+  drag: number;
+  rotation: number;
+  spin: number;
+  type: 'spark' | 'trail';
+}
+
+interface ExplosionRing {
+  x: number;
+  y: number;
+  radius: number;
+  maxRadius: number;
+  life: number;
+  maxLife: number;
+  color: string;
+}
+
+const bulletQuery = defineQuery([Bullet, Position, Velocity, Render]);
+const enemyQuery = defineQuery([Enemy, Position, Velocity, Render]);
+const playerQuery = defineQuery([Player, Position, Velocity]);
+
+function rgba(r: number, g: number, b: number, a = 1): string {
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+export class ParticleSystem {
+  private particles: Particle[] = [];
+  private rings: ExplosionRing[] = [];
+  private maxParticles = 800;
+
+  reset(): void {
+    this.particles.length = 0;
+    this.rings.length = 0;
+  }
+
+  update(dt: number): void {
+    for (let i = this.particles.length - 1; i >= 0; i--) {
+      const p = this.particles[i];
+      p.life -= dt;
+      if (p.life <= 0) {
+        this.particles.splice(i, 1);
+        continue;
+      }
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      p.vx *= p.drag;
+      p.vy *= p.drag;
+      p.rotation += p.spin * dt;
+      p.alpha = Math.max(0, p.life / p.maxLife);
+    }
+
+    for (let i = this.rings.length - 1; i >= 0; i--) {
+      const ring = this.rings[i];
+      ring.life -= dt;
+      if (ring.life <= 0) {
+        this.rings.splice(i, 1);
+        continue;
+      }
+      const t = 1 - ring.life / ring.maxLife;
+      ring.radius = ring.maxRadius * t * t;
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    for (let i = 0; i < this.particles.length; i++) {
+      const p = this.particles[i];
+      const radius = p.size * (0.4 + 0.6 * (p.life / p.maxLife));
+      ctx.shadowBlur = p.glow;
+      ctx.shadowColor = p.color;
+      ctx.globalAlpha = p.alpha;
+      if (p.type === 'trail') {
+        ctx.save();
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rotation);
+        const len = radius * 2.8;
+        ctx.fillStyle = p.color;
+        ctx.fillRect(-len * 0.5, -radius * 0.35, len, radius * 0.7);
+        ctx.restore();
+      } else {
+        const gradient = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, radius);
+        gradient.addColorStop(0, 'rgba(255,255,255,1)');
+        gradient.addColorStop(0.5, p.color);
+        gradient.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+    ctx.restore();
+
+    for (let i = 0; i < this.rings.length; i++) {
+      const ring = this.rings[i];
+      const alpha = Math.max(0, ring.life / ring.maxLife);
+      ctx.globalAlpha = alpha;
+      ctx.strokeStyle = ring.color;
+      ctx.lineWidth = 4;
+      ctx.shadowBlur = 25;
+      ctx.shadowColor = ring.color;
+      ctx.beginPath();
+      ctx.arc(ring.x, ring.y, ring.radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+    ctx.shadowBlur = 0;
+  }
+
+  private emitParticle(particle: Particle): void {
+    if (this.particles.length >= this.maxParticles) {
+      this.particles.shift();
+    }
+    this.particles.push(particle);
+  }
+
+  muzzleFlash(x: number, y: number, primaryColor = 'rgba(255,220,120,1)'): void {
+    for (let i = 0; i < 10; i++) {
+      this.emitParticle({
+        x,
+        y,
+        vx: (Math.random() * 60 + 80) * (0.6 + Math.random() * 0.4),
+        vy: (Math.random() - 0.5) * 80,
+        life: 0.18 + Math.random() * 0.12,
+        maxLife: 0.3,
+        size: 10 + Math.random() * 6,
+        color: primaryColor,
+        glow: 20,
+        alpha: 1,
+        drag: 0.8,
+        rotation: Math.random() * Math.PI * 2,
+        spin: 0,
+        type: 'spark',
+      });
+    }
+  }
+
+  hitBurst(x: number, y: number, color: string): void {
+    for (let i = 0; i < 18; i++) {
+      const angle = (Math.PI * 2 * i) / 18 + Math.random() * 0.2;
+      const speed = 90 + Math.random() * 120;
+      this.emitParticle({
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life: 0.35 + Math.random() * 0.2,
+        maxLife: 0.5,
+        size: 8 + Math.random() * 5,
+        color,
+        glow: 25,
+        alpha: 1,
+        drag: 0.88,
+        rotation: angle,
+        spin: 0,
+        type: 'spark',
+      });
+    }
+  }
+
+  explosion(x: number, y: number, color: string): void {
+    for (let i = 0; i < 24; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 100 + Math.random() * 140;
+      this.emitParticle({
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        life: 0.45 + Math.random() * 0.4,
+        maxLife: 0.7,
+        size: 14 + Math.random() * 10,
+        color,
+        glow: 30,
+        alpha: 1,
+        drag: 0.86,
+        rotation: angle,
+        spin: 0,
+        type: 'spark',
+      });
+    }
+    this.rings.push({
+      x,
+      y,
+      radius: 0,
+      maxRadius: 120,
+      life: 0.6,
+      maxLife: 0.6,
+      color,
+    });
+  }
+
+  addTrail(x: number, y: number, angle: number, color: string, intensity = 1): void {
+    const speed = 40 + Math.random() * 20;
+    this.emitParticle({
+      x,
+      y,
+      vx: Math.cos(angle) * speed * -0.3,
+      vy: Math.sin(angle) * speed * -0.3,
+      life: 0.3 + Math.random() * 0.15,
+      maxLife: 0.45,
+      size: 16 * intensity,
+      color,
+      glow: 18,
+      alpha: 1,
+      drag: 0.92,
+      rotation: angle,
+      spin: 0,
+      type: 'trail',
+    });
+  }
+
+  syncTrails(world: World): void {
+    const bullets = bulletQuery(world);
+    for (let i = 0; i < bullets.length; i++) {
+      const b = bullets[i];
+      const angle = Math.atan2(Velocity.vy[b], Velocity.vx[b] || 1e-5);
+      const color = rgba(Render.r[b], Render.g[b], Render.b[b], 1);
+      this.addTrail(Position.x[b], Position.y[b], angle, color, 0.4);
+    }
+
+    const enemies = enemyQuery(world);
+    for (let i = 0; i < enemies.length; i++) {
+      const e = enemies[i];
+      const velAngle = Math.atan2(Velocity.vy[e], Velocity.vx[e] || 1e-5);
+      const color = rgba(Render.r[e], Render.g[e], Render.b[e], 0.9);
+      this.addTrail(Position.x[e], Position.y[e], velAngle, color, 0.7);
+    }
+
+    const players = playerQuery(world);
+    for (let i = 0; i < players.length; i++) {
+      const p = players[i];
+      const velAngle = Math.atan2(Velocity.vy[p], Velocity.vx[p] || 1e-5);
+      const speed = Math.hypot(Velocity.vx[p], Velocity.vy[p]);
+      if (speed > 15) {
+        this.addTrail(Position.x[p], Position.y[p], velAngle, 'rgba(0,255,255,0.9)', 1);
+      }
+    }
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5,26 +5,49 @@ export class HUD {
   private scoreEl: HTMLElement;
   private waveEl: HTMLElement;
   private levelEl: HTMLElement;
+  private healthFillEl: HTMLElement;
+  private healthTextEl: HTMLElement;
 
   private last: Partial<GameState> = {};
 
   constructor(root: HTMLElement) {
     this.root = root;
     this.root.innerHTML = `
-      <div style="position:absolute;top:12px;left:12px;background:rgba(0,0,0,0.4);border:1px solid rgba(0,255,255,0.3);padding:8px 12px;border-radius:6px;pointer-events:none;">
-        <div>Score: <span id="hud-score">0</span></div>
-        <div>Wave: <span id="hud-wave">1</span></div>
-        <div>Level: <span id="hud-level">1</span></div>
+      <div class="hud-container">
+        <div class="hud-row">
+          <div class="hud-pill">⭐ SCORE: <span data-hud="score">0</span></div>
+        </div>
+        <div class="hud-row hud-health-block">
+          <div class="hud-label">❤️ HEALTH</div>
+          <div class="hud-health">
+            <div class="hud-health-fill" data-hud="health-fill"></div>
+            <div class="hud-health-text" data-hud="health-text">100 / 100</div>
+          </div>
+        </div>
+        <div class="hud-row hud-inline">
+          <div class="hud-pill">🌊 WAVE: <span data-hud="wave">1</span></div>
+          <div class="hud-pill">🎯 LEVEL: <span data-hud="level">1</span></div>
+        </div>
       </div>`;
-    this.scoreEl = this.root.querySelector('#hud-score') as HTMLElement;
-    this.waveEl = this.root.querySelector('#hud-wave') as HTMLElement;
-    this.levelEl = this.root.querySelector('#hud-level') as HTMLElement;
+    this.scoreEl = this.root.querySelector('[data-hud="score"]') as HTMLElement;
+    this.waveEl = this.root.querySelector('[data-hud="wave"]') as HTMLElement;
+    this.levelEl = this.root.querySelector('[data-hud="level"]') as HTMLElement;
+    this.healthFillEl = this.root.querySelector('[data-hud="health-fill"]') as HTMLElement;
+    this.healthTextEl = this.root.querySelector('[data-hud="health-text"]') as HTMLElement;
   }
 
   update(s: GameState) {
     if (s.score !== this.last.score) this.scoreEl.textContent = String(s.score);
     if (s.wave !== this.last.wave) this.waveEl.textContent = String(s.wave);
     if (s.level !== this.last.level) this.levelEl.textContent = String(s.level);
+    if (
+      s.playerHealth !== this.last.playerHealth ||
+      s.playerMaxHealth !== this.last.playerMaxHealth
+    ) {
+      const ratio = s.playerMaxHealth > 0 ? s.playerHealth / s.playerMaxHealth : 0;
+      this.healthFillEl.style.width = `${Math.max(0, Math.min(1, ratio)) * 100}%`;
+      this.healthTextEl.textContent = `${Math.max(0, Math.round(s.playerHealth))} / ${Math.round(s.playerMaxHealth)}`;
+    }
     this.last = { ...s };
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the 2D renderer around gradient sprites, screen shake, and a reusable starfield and particle system
- update the ECS world and systems to drive trails, explosions, and health tracking for a neon HUD
- refresh the HTML/CSS shell with the legacy neon chrome and health display widgets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de5821606c832d8335bb380a708b99